### PR TITLE
Adds scale srcset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then you have to create a ``responsiveimage.php`` inside your ``site/tags`` with
 ```
 <?php
 require_once('kirby-responsive-images/responsiveimage.php');
-``
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ A simple drop-in implementation of [responsive images](https://responsiveimages.
 [Download the latest release](https://github.com/jancbeck/kirby-responsive-images/releases/) and unpack to your kirby `/site/tags` directory.
 
 Alternatively you can:
+
 ``git clone https://github.com/jancbeck/kirby-responsive-images.git site/tags/kirby-responsive-images``
-From the root of your kirby install. Then you have to create a ``responsiveimage.php`` inside your ``site/tags`` with following content:
+From the root of your kirby install. 
+
+Then you have to create a ``responsiveimage.php`` inside your ``site/tags`` with following content:
 
 ```
 <?php

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require_once('kirby-responsive-images/responsiveimage.php');
 
 ## Usage
 
-There nothing you need to change in order to have responsive image support. Just include images as you would do normally:
+You will then have the new responsiveimage tag avalible:
 
 `(responsiveimage:workflow@3x.jpg link:workflow@3x.jpg width:1244)`
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ A simple drop-in implementation of [responsive images](https://responsiveimages.
 
 ## Installation
 
-[Download the latest release](https://github.com/jancbeck/kirby-responsive-images/releases/) and unpack to your kirby `/site/plugins` directory.
+[Download the latest release](https://github.com/jancbeck/kirby-responsive-images/releases/) and unpack to your kirby `/site/tags` directory.
+
+Alternatively you can:
+``git clone https://github.com/jancbeck/kirby-responsive-images.git site/tags/kirby-responsive-images``
+From the root of your kirby install. Then you have to create a ``responsiveimage.php`` inside your ``site/tags`` with following content:
+
+```
+<?php
+require_once('kirby-responsive-images/responsiveimage.php');
+``
 
 ## Usage
 
 There nothing you need to change in order to have responsive image support. Just include images as you would do normally:
 
-`(image:workflow@3x.jpg link:workflow@3x.jpg width:1244)`
+`(responsiveimage:workflow@3x.jpg link:workflow@3x.jpg width:1244)`
 
 Make sure your `/thumbs` directory is present and writable and ImageMagick is available.
 
@@ -57,6 +66,25 @@ c::set('responsiveimages.sources', array(
 
 1. The key names are optional and have no technical implications.
 2. Each array item takes the same arguments as Kirbys [thumb()](http://getkirby.com/docs/cheatsheet/helpers/thumb) function (`quality`, `blur`, `upscale` etc..).
+
+### Scale
+
+You can also use the `usescale` option to create a scale based srcset. It will take the name of the file as reference to auto generate the other scales.
+`workflow@3x.jpg` will create a srcset with a `3x`, `2x` and `1x` entry.
+
+`(responsiveimage:workflow@3x.jpg usescale:true)`
+
+It's important to define the correct basescale with the `@…x` pattern in your filename.
+
+scale and sizes can't be mixed see: [Stackoverlow answer](http://stackoverflow.com/questions/26928828/html5-srcset-mixing-x-and-w-syntax/26937237#26937237)
+
+### Template usage
+
+You can use the responsive image tag directly in you template using the [Kirbytag](http://getkirby.com/docs/cheatsheet/helpers/kirbytag) helper function: 
+
+```
+<?php echo kirbytag(array('responsiveimage' => 'workflow@3x.jpg', 'link' => 'workflow@3x.jpg', 'width' => 1244)); ?>
+```
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ scale and sizes can't be mixed see: [Stackoverlow answer](http://stackoverflow.c
 
 ### Template usage
 
-You can use the responsive image tag directly in you template using the [Kirbytag](http://getkirby.com/docs/cheatsheet/helpers/kirbytag) helper function: 
+You can use the responsive image tag directly inside your template using the [Kirbytag](http://getkirby.com/docs/cheatsheet/helpers/kirbytag) helper function: 
 
 ```
 <?php echo kirbytag(array('responsiveimage' => 'workflow@3x.jpg', 'link' => 'workflow@3x.jpg', 'width' => 1244)); ?>

--- a/responsive-images.php
+++ b/responsive-images.php
@@ -118,19 +118,50 @@ kirbytext::$tags['image'] = array(
 );
 
 /**
+ *  Returns the image scale based on the filename
+ *  2x will return a scale of 2 e.g.
+ *
+ *  @param   File  $file
+ *
+ *  @return  int
+ */
+function kirby_get_image_scale($file) {
+    $file_name_parts = explode("@", $file->name());
+    if(count($file_name_parts)) {
+        $last_part = end($file_name_parts);
+        return intval(str_replace('x', '', $last_part));
+    }
+}
+
+/**
  *  Returns the srcset attribute value for a given Kirby file
  *  Generates thumbnails on the fly
  *
  *  @param   File  $file
  *  @uses   kirby_get_srcset_array
+ *  @uses   kirby_get_image_scale
  *  @uses   thumb
  *
  *  @return  string
  */
 function kirby_get_srcset( $file ) {
-    $srcset = $file->url() .' '. $file->width() .'w';
+    $srcset = "";
     $sources_arr = kirby_get_srcset_array( $file );
 
+    $scale = kirby_get_image_scale($file);
+    if($scale) {
+        $srcset .= ''. $file->url() .' '.$scale.'x';
+        for ($i=$scale-1; $i > 0; $i--) {
+            $thumb = thumb($file, array('width' => $file->width() * ($i / $scale) ));
+            $srcset .= ', '. $thumb->url() .' '. $i .'x';
+        }
+
+    }
+
+    if($srcset != '')
+        $srcset .= ', ';
+
+    $srcset .= $file->url() .' '. $file->width() .'w';
     foreach ($sources_arr as $source) {
         $thumb = thumb($file, $source);
         $srcset .= ', '. $thumb->url() .' '. $thumb->width() .'w';

--- a/responsiveimage.php
+++ b/responsiveimage.php
@@ -1,7 +1,7 @@
 <?php
 
-// image tag
-kirbytext::$tags['image'] = array(
+// responsiveimage tag
+kirbytext::$tags['responsiveimage'] = array(
   'attr' => array(
     'width',
     'height',
@@ -17,21 +17,27 @@ kirbytext::$tags['image'] = array(
     'popup',
     'rel',
     'srcset',
-    'sizes'
+    'sizes',
+    'usescale',
+    'sizeattr'
   ),
   'html' => function($tag) {
 
-    $url     = $tag->attr('image');
-    $alt     = $tag->attr('alt');
-    $title   = $tag->attr('title');
-    $link    = $tag->attr('link');
-    $caption = $tag->attr('caption');
-    $srcset  = $tag->attr('srcset');
-    $sizes   = $tag->attr('sizes');
-    $file    = $tag->file($url);
+    $url       = $tag->attr('responsiveimage');
+    $alt       = $tag->attr('alt');
+    $title     = $tag->attr('title');
+    $link      = $tag->attr('link');
+    $caption   = $tag->attr('caption');
+    $srcset    = $tag->attr('srcset');
+    $sizes     = $tag->attr('sizes');
+    $use_scale = $tag->attr('usescale');
+    $size_attr = $tag->attr('sizeattr');
+    $file      = $tag->file($url);
 
     // use the file url if available and otherwise the given url
     $url = $file ? $file->url() : url($url);
+    $use_scale = $use_scale == "true" || $use_scale == true;
+    $size_attr = $size_attr == "true" || $size_attr == true;
 
     // alt is just an alternative for text
     if($text = $tag->attr('text')) $alt = $text;
@@ -49,7 +55,15 @@ kirbytext::$tags['image'] = array(
 
     }
 
-    if(empty($alt)) $alt = pathinfo($url, PATHINFO_FILENAME);
+    $width = null;
+    $height = null;
+    if($size_attr && $file) {
+        $image_scale = kirby_get_image_scale($file);
+        $width = ($tag->attr('width') | $file->width()) / $image_scale;
+        $height = ($tag->attr('height') | $file->height()) / $image_scale;
+    }
+
+    if(empty($alt) && $alt != "") $alt = pathinfo($url, PATHINFO_FILENAME);
 
     // link builder
     $_link = function($image) use($tag, $url, $link, $file) {
@@ -78,20 +92,21 @@ kirbytext::$tags['image'] = array(
 
     //srcset builder
     if($file && empty($srcset)) {
-    	$srcset = kirby_get_srcset($file);
+    	$srcset = kirby_get_srcset($file, $use_scale);
     }
 
     //sizes builder
-    if($file && empty($sizes)) {
+    $sizes = null;
+    if(!$use_scale && $file && empty($sizes)) {
         $classes = ( ! empty( $tag->attr('imgclass'))) ? explode( ' ', $tag->attr('imgclass')) : '';
     	$sizes = kirby_get_sizes($file, $tag->attr('width'), $classes);
 	}
 
     // image builder
-    $_image = function($class) use($tag, $url, $alt, $title, $srcset, $sizes) {
+    $_image = function($class) use($tag, $url, $alt, $title, $srcset, $sizes, $width, $height) {
       return html::img($url, array(
-        'width'  => $tag->attr('width'),
-        'height' => $tag->attr('height'),
+        'width'  => $width | $tag->attr('width'),
+        'height' => $height | $tag->attr('height'),
         'class'  => $class,
         'title'  => $title,
         'alt'    => $alt,
@@ -125,7 +140,7 @@ kirbytext::$tags['image'] = array(
  *
  *  @return  int
  */
-function kirby_get_image_scale($file) {
+function kirby_get_image_scale( $file ) {
     $file_name_parts = explode("@", $file->name());
     if(count($file_name_parts)) {
         $last_part = end($file_name_parts);
@@ -144,27 +159,26 @@ function kirby_get_image_scale($file) {
  *
  *  @return  string
  */
-function kirby_get_srcset( $file ) {
+function kirby_get_srcset( $file, $use_scale ) {
     $srcset = "";
     $sources_arr = kirby_get_srcset_array( $file );
 
-    $scale = kirby_get_image_scale($file);
-    if($scale) {
-        $srcset .= ''. $file->url() .' '.$scale.'x';
-        for ($i=$scale-1; $i > 0; $i--) {
-            $thumb = thumb($file, array('width' => $file->width() * ($i / $scale) ));
-            $srcset .= ', '. $thumb->url() .' '. $i .'x';
+    if($use_scale) {
+        $scale = kirby_get_image_scale($file);
+        if($scale) {
+            $srcset .= ''. $file->url() .' '.$scale.'x';
+            for ($i=$scale-1; $i > 0; $i--) {
+                $thumb = thumb($file, array('width' => $file->width() * ($i / $scale) ));
+                $srcset .= ', '. $thumb->url() .' '. $i .'x';
+            }
+
         }
-
-    }
-
-    if($srcset != '')
-        $srcset .= ', ';
-
-    $srcset .= $file->url() .' '. $file->width() .'w';
-    foreach ($sources_arr as $source) {
-        $thumb = thumb($file, $source);
-        $srcset .= ', '. $thumb->url() .' '. $thumb->width() .'w';
+    } else {
+        $srcset .= $file->url() .' '. $file->width() .'w';
+        foreach ($sources_arr as $source) {
+            $thumb = thumb($file, $source);
+            $srcset .= ', '. $thumb->url() .' '. $thumb->width() .'w';
+        }
     }
     return $srcset;
 }


### PR DESCRIPTION
Hi,

this will add the scale option to the responsive images (1x, 2x, 3x, …) based on the image filename.

I also renamed the tag to `responsiveimage` to keep the core image tag untouched. I also changed the readme to use the `tags` folder instead of the `plugins` folder. 

What do you think? I think it's cleaner if you can choose if you want to create extra files using `responsiveimage` or not using the original `image` tag. 
